### PR TITLE
refactor: move api fetching to BaseEventDisplay

### DIFF
--- a/components/EventDisplay/BaseEventDisplay.vue
+++ b/components/EventDisplay/BaseEventDisplay.vue
@@ -1,7 +1,7 @@
 <template>
   <WarnNoSetStreet/>
 
-  <v-container v-if="props.fetchError">
+  <v-container v-if="fetchError">
     <v-alert 
       type="error"
       :title="i18n.t('baseEventDisplay.fetchErrorTitle')"
@@ -9,11 +9,11 @@
     />
   </v-container>
 
-  <v-container v-if="props.eventData">
+  <v-container v-if="eventData">
 
     <EventDisplayDataIterator
-      :event-data="props.eventData"
-      :is-loading="props.fetchStatus === 'pending'"
+      :event-data="eventData"
+      :is-loading="fetchStatus === 'pending'"
       />
 
   </v-container>
@@ -32,17 +32,30 @@
   import WarnNoSetStreet from "../WarnNoSetStreet.vue";
   import EventDisplayDataIterator from "./EventDisplayDataIterator.vue";
   import type { AwsApiServiceResponseAll } from "~/server/services/AwsApiService.js"
-  import type { AsyncDataRequestStatus } from "#app";
-  import type { FetchError } from 'ofetch'
 
   const { i18n, multiMergeLocaleMessage } = useCustomI18n();
 
-  const props = defineProps<{ 
-    eventData: AwsApiServiceResponseAll | null;
-    fetchStatus: AsyncDataRequestStatus;
-    fetchError: FetchError<unknown> | null;
+  const props = defineProps<{
+    apiEndpoint: string;
   }>();
-  //const { cookieStreet, hasSetStreet } = useCookieUserConfig();
+
+  const { cookieStreet } = useCookieUserConfig();
+
+  const streetname = toRef(() => cookieStreet.value.streetname);
+  const streetno = toRef(() => cookieStreet.value.streetno);
+
+  //@TODO https://nuxt.com/docs/guide/recipes/custom-usefetch#custom-usefetch
+  //@TODO - fix empty api call, when no streetname/streetno is set
+  const { data: eventData, status: fetchStatus, error: fetchError } = await useFetch<AwsApiServiceResponseAll>(props.apiEndpoint, {
+    query: {
+      streetname: streetname,
+      streetno: streetno
+    },
+  });
+
+
+
+
 
   multiMergeLocaleMessage("baseEventDisplay", [
     [

--- a/pages/Upcoming.vue
+++ b/pages/Upcoming.vue
@@ -1,21 +1,15 @@
 <template>
   <v-container>
     <h1>{{ i18n.t("upcoming.pageTitle") }}</h1>
-    <p>{{ i18n.t("upcoming.pageSubtitle", { address: `${streetname} ${streetno}` }) }}</p>
+    <p>{{ i18n.t("upcoming.pageSubtitle", { address: `${cookieStreet.streetname} ${cookieStreet.streetno}` }) }}</p>
 
-    <BaseEventDisplay
-      :event-data="apiData"
-      :fetch-status="apiStatus"
-      :fetch-error="apiError"
-    />
+    <BaseEventDisplay api-endpoint="/api/v1/upcoming"/>
 </v-container>
 </template>
 
 <script setup lang="ts">
-
-  import type { AwsApiServiceResponseAll } from "~/server/services/AwsApiService.js"
+  import BaseEventDisplay from "~/components/EventDisplay/BaseEventDisplay.vue";
   import { useCookieUserConfig } from "~/composables/useCookieUserConfig";
-import BaseEventDisplay from "~/components/EventDisplay/BaseEventDisplay.vue";
 
   const { cookieStreet } = useCookieUserConfig();
 
@@ -24,18 +18,5 @@ import BaseEventDisplay from "~/components/EventDisplay/BaseEventDisplay.vue";
     ["pageTitle", {de: "Bevorstehende Abholungen", en: "Upcoming Pickups"}],
     ["pageSubtitle", {de: "Die bevorstehende Abholungen für { address }", en: "The next upcoming pickups for { address }"}],
   ]);
-
-  const streetname = toRef(() => cookieStreet.value.streetname);
-  const streetno = toRef(() => cookieStreet.value.streetno);
-
-  //@TODO https://nuxt.com/docs/guide/recipes/custom-usefetch#custom-usefetch
-  //@TODO - fix empty api call, when no streetname/streetno is set
-  const { data: apiData, status: apiStatus, error: apiError } = await useFetch<AwsApiServiceResponseAll>("/api/v1/upcoming", {
-    query: {
-      streetname: streetname,
-      streetno: streetno
-    },
-  });
-
 
 </script>

--- a/pages/all.vue
+++ b/pages/all.vue
@@ -1,41 +1,22 @@
 <template>
   <v-container>
     <h1>{{ i18n.t("all.pageTitle") }}</h1>
-    <p>{{ i18n.t("all.pageSubtitle", { address: `${streetname} ${streetno}` }) }}</p>
+    <p>{{ i18n.t("all.pageSubtitle", { address: `${cookieStreet.streetname} ${cookieStreet.streetno}` }) }}</p>
 
-    <BaseEventDisplay
-      :event-data="apiData"
-      :fetch-status="apiStatus"
-      :fetch-error="apiError"
-    />
+    <BaseEventDisplay api-endpoint="/api/v1/all"/>
   </v-container>
 </template>
 
 <script setup lang="ts">
-
-  import type { AwsApiServiceResponseAll } from "~/server/services/AwsApiService.js"
-  import { useCookieUserConfig } from "~/composables/useCookieUserConfig";
   import BaseEventDisplay from "~/components/EventDisplay/BaseEventDisplay.vue";
+  import { useCookieUserConfig } from "~/composables/useCookieUserConfig";
 
   const { cookieStreet } = useCookieUserConfig();
-  const { i18n, multiMergeLocaleMessage }  = useCustomI18n();
+  const { i18n, multiMergeLocaleMessage } = useCustomI18n();
 
   multiMergeLocaleMessage("all", [
     ["pageTitle", {de: "Alle Abholungen", en: "All Pickups"}],
     ["pageSubtitle", {de: "Alle geplanten Abholungen für { address }", en: "All scheduled pickups for { address }"}],
   ]);
-
-  const streetname = toRef(() => cookieStreet.value.streetname);
-  const streetno = toRef(() => cookieStreet.value.streetno);
-
-  //@TODO https://nuxt.com/docs/guide/recipes/custom-usefetch#custom-usefetch
-  //@TODO - fix empty api call, when no streetname/streetno is set
-  const { data: apiData, status: apiStatus, error: apiError } = await useFetch<AwsApiServiceResponseAll>("/api/v1/all", {
-    query: {
-      streetname: streetname,
-      streetno: streetno
-    },
-  });
-
 
 </script>


### PR DESCRIPTION
Moved the API fetching calls from the page to the BaseEventDisplay component, to reduce unnecessary code duplication