### PR TITLE
feat(schemaQueryICal): prevent iCalendar "injections"

### DIFF
--- a/server/validationSchemas/schemaQueryICal.ts
+++ b/server/validationSchemas/schemaQueryICal.ts
@@ -20,7 +20,7 @@ export const schemaQueryICal = schemaQuery.extend({
   allDay: z.coerce.boolean().optional(),
   alarm: z.coerce.number().min(0).max(999_999).optional(),
   offsetEvent: z.coerce.number().min(0).max(999).optional(),
-  customSummary: z.string().max(600).optional()
+  customSummary: z.string().max(100).optional()
 })
 
 export type ApiQueryICal = z.infer<typeof schemaQueryICal>;

--- a/server/validationSchemas/schemaQueryICal.ts
+++ b/server/validationSchemas/schemaQueryICal.ts
@@ -20,7 +20,7 @@ export const schemaQueryICal = schemaQuery.extend({
   allDay: z.coerce.boolean().optional(),
   alarm: z.coerce.number().min(0).max(999_999).optional(),
   offsetEvent: z.coerce.number().min(0).max(999).optional(),
-  customSummary: z.string().max(100).optional()
+  customSummary: z.string().max(100).regex(/^[^\r\n]+$/).optional()
 })
 
 export type ApiQueryICal = z.infer<typeof schemaQueryICal>;

--- a/server/validationSchemas/schemaQueryICal.unit.test.ts
+++ b/server/validationSchemas/schemaQueryICal.unit.test.ts
@@ -30,4 +30,28 @@ describe("schemaQueryICal Unit Tests", () => {
     assert.isUndefined(result.data?.endTime);
   })
 
+  it("should fail, if custom summary contains a CRLF sequence", () => {
+    const fakeData = { streetname: "Test Str.", streetno: "123", format: "ical", startTime: "6:00", endTime: "12:30", customSummary: "Abc Def\r\nGhij" }
+    const result = schemaQueryICal.safeParse(fakeData)
+    assert.isFalse(result.success);
+  })
+
+  it("should fail, if custom summary contains a CR sequence", () => {
+    const fakeData = { streetname: "Test Str.", streetno: "123", format: "ical", startTime: "6:00", endTime: "12:30", customSummary: "Abc Def\rGhij" }
+    const result = schemaQueryICal.safeParse(fakeData)
+    assert.isFalse(result.success);
+  })
+
+  it("should fail, if custom summary contains a LF sequence", () => {
+    const fakeData = { streetname: "Test Str.", streetno: "123", format: "ical", startTime: "6:00", endTime: "12:30", customSummary: "Abc Def\nGhij" }
+    const result = schemaQueryICal.safeParse(fakeData)
+    assert.isFalse(result.success);
+  })
+
+  it("should pass, if custom summary contains valid text < 100 chars", () => {
+    const fakeData = { streetname: "Test Str.", streetno: "123", format: "ical", startTime: "6:00", endTime: "12:30", customSummary: "Abc Def Ghij %1 (%2)" }
+    const result = schemaQueryICal.safeParse(fakeData)
+    assert.isTrue(result.success);
+  })
+
 })


### PR DESCRIPTION
Prevent the possibility to inject unwanted iCalendar content, via the custom summary field in the iCal Generator:
Previously one could have added the CRLF characters in the string and then use that to add own content to the iCalendar - which is NOT what we want :-)

Prevention done by rejecting any strings with CRLF in them and also restricting summary length to 100 characters

closes #30 
(even though it takes a more simple approach instead of filtering out *all* iCalendar related keywords)